### PR TITLE
Send messages in one SMTP transaction

### DIFF
--- a/control.py
+++ b/control.py
@@ -76,11 +76,11 @@ def SndEmail(settings, notifyevent):
 			event = subjectmessage + ". E-mail notification sent to: " + addr
 			WriteLog(event)
 
-	except smtplib.SMTPException:
-		event = "E-mail notification failed. SMTPLib general exception class(smptlib.SMTPException)."
+	except smtplib.SMTPException as e:
+		event = "E-mail notification failed. SMTPLib general exception: %s" % e
 		WriteLog(event)
-	except:
-		event = "E-mail notification failed, for some unknown reason."
+	except Exception as e:
+		event = "E-mail notification failed, with exception: %s" % e
 		WriteLog(event)
 	return()
 

--- a/control.py
+++ b/control.py
@@ -56,33 +56,25 @@ def SndEmail(settings, notifyevent):
 	try:
 		fromaddr = settings['email']['FromEmail']
 		toaddr = settings['email']['ToEmail']
-		# If there are commas in the string, this means there are likely to be multiple e-mail addresses
-		if(',' in toaddr):
-			# process string to remove spaces
-			toaddr = toaddr.replace(" ", "")
-			# process string into list of e-mail addresses
-			toaddrlist = toaddr.split(",")
-		else:
-			toaddrlist = [toaddr]
+		toaddrlist = [addr.strip() for addr in toaddr.split(',')] # split on commas and strip out any spaces
 
-		index = 0
-		while(index < len(toaddrlist)):
-			msg = MIMEMultipart()
-			msg['From'] = fromaddr
-			msg['To'] = toaddrlist[index]
-			msg['Subject'] = subjectmessage
-			body = notifymessage
-			msg.attach(MIMEText(body, 'plain'))
+		msg = MIMEMultipart()
+		msg['From'] = fromaddr
+		msg['To'] = ', '.join(toaddrlist)
+		msg['Subject'] = subjectmessage
+		body = notifymessage
+		msg.attach(MIMEText(body, 'plain'))
 
-			server = smtplib.SMTP(settings['email']['SMTPServer'], settings['email']['SMTPPort'])
-			server.starttls()
-			server.login(fromaddr, settings['email']['Password'])
-			text = msg.as_string()
-			server.sendmail(fromaddr, toaddrlist[index], text)
-			server.quit()
-			event = subjectmessage + ". E-mail notification sent to: " + toaddrlist[index]
+		server = smtplib.SMTP(settings['email']['SMTPServer'], settings['email']['SMTPPort'])
+		server.starttls()
+		server.login(fromaddr, settings['email']['Password'])
+		text = msg.as_string()
+		server.sendmail(fromaddr, toaddrlist, text)
+		server.quit()
+
+		for addr in toaddrlist:
+			event = subjectmessage + ". E-mail notification sent to: " + addr
 			WriteLog(event)
-			index += 1
 
 	except smtplib.SMTPException:
 		event = "E-mail notification failed. SMTPLib general exception class(smptlib.SMTPException)."


### PR DESCRIPTION
This change will send all the notifications in one SMTP transaction rather than multiple. Also, log the reason if there are any failures.

This isn't particularly important, the way you had was working ok! But it's a bit more efficient.