### PR TITLE
run control app as non-root user once added to the gpio group

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ Follow the onscreen prompts to complete the installation.  At the end of the scr
 
 ### Manual Software installation (Recommended)
 
+#### Give pi user access to the GPIO pins
+```
+sudo adduser pi gpio
+```
+
 #### Install Git, Python PIP, Flask, Gunicorn, nginx, and supervisord
 ```
 sudo apt update

--- a/garage-zero-control.service
+++ b/garage-zero-control.service
@@ -4,8 +4,8 @@ Wants=network.target
 After=network.target
 
 [Service]
-User=root
-Group=root
+User=pi
+Group=pi
 WorkingDirectory=/home/pi/garage-zero
 ExecStart=/usr/bin/python control.py
 Restart=always

--- a/webapp.conf
+++ b/webapp.conf
@@ -6,4 +6,4 @@ autorestart=true
 startretries=3
 stderr_logfile=/home/pi/garage-zero/logs/webapp.err.log
 stdout_logfile=/home/pi/garage-zero/logs/webapp.out.log
-user=root
+user=pi


### PR DESCRIPTION
If you add the pi user to the gpio group then control.py runs just fine as pi rather than root.